### PR TITLE
Adding missing "warnings" import

### DIFF
--- a/wand/resource.py
+++ b/wand/resource.py
@@ -8,6 +8,7 @@ implements automatic global resource management through reference counting.
 import logging
 import contextlib
 import ctypes
+import warnings
 from . import exceptions
 from .api import library
 
@@ -20,7 +21,7 @@ def genesis():
     """Instantiates the MagickWand API.
 
     .. warning::
-    
+
        Don't call this function directly. Use :func:`increment_refcount()` and
        :func:`decrement_refcount()` functions instead.
 
@@ -32,7 +33,7 @@ def terminus():
     """Cleans up the MagickWand API.
 
     .. warning::
-    
+
        Don't call this function directly. Use :func:`increment_refcount()` and
        :func:`decrement_refcount()` functions instead.
 

--- a/wandtests/resource.py
+++ b/wandtests/resource.py
@@ -43,3 +43,30 @@ def negative_refcount():
     with raises(RuntimeError) as error:
         resource.decrement_refcount()
 
+@tests.test
+def raises_exceptions():
+    """Exceptions raise, and warnings warn"""
+    from wand import resource
+    exceptions = resource.exceptions
+    class DummyResource(resource.Resource):
+
+        def set_exception_type(self, idx):
+            self.exception_index = idx
+
+        def get_exception(self):
+            exc_cls = exceptions.TYPE_MAP[self.exception_index]
+            return exc_cls("Dummy exception")
+
+    for code in exceptions.TYPE_MAP.keys():
+        resource = DummyResource()
+        resource.set_exception_type(code)
+        import warnings
+        with warnings.catch_warnings(record=True) as w:
+            try:
+                resource.raise_exception()
+                assert len(w) == 1
+                assert w[-1].category.__name__.endswith('Warning')
+                assert "Dummy exception" in str(w[-1].message)
+            except exceptions.WandException as e:
+                assert not e.__class__.__name__.endswith('Warning')
+                assert e.message == 'Dummy exception'


### PR DESCRIPTION
Warnings failed with an exception, due to a missing `import warnings`.

This patch also adds a test to ensure warnings do warn rather than raise.
