### PR TITLE
Throw ImportError on shared library load failure

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -83,131 +83,134 @@ library = libraries[0]
 #: :data:`library` on platforms other than Windows.
 libmagick = libraries[1]
 
-library.NewMagickWand.restype = ctypes.c_void_p
+try:
+    library.NewMagickWand.restype = ctypes.c_void_p
 
-library.DestroyMagickWand.argtypes = [ctypes.c_void_p]
-library.DestroyMagickWand.restype = ctypes.c_void_p
+    library.DestroyMagickWand.argtypes = [ctypes.c_void_p]
+    library.DestroyMagickWand.restype = ctypes.c_void_p
 
-library.CloneMagickWand.argtypes = [ctypes.c_void_p]
-library.CloneMagickWand.restype = ctypes.c_void_p
+    library.CloneMagickWand.argtypes = [ctypes.c_void_p]
+    library.CloneMagickWand.restype = ctypes.c_void_p
 
-library.IsMagickWand.argtypes = [ctypes.c_void_p]
+    library.IsMagickWand.argtypes = [ctypes.c_void_p]
 
-library.MagickGetException.argtypes = [ctypes.c_void_p,
-                                       ctypes.POINTER(ctypes.c_int)]
-library.MagickGetException.restype = ctypes.c_char_p
+    library.MagickGetException.argtypes = [ctypes.c_void_p,
+                                           ctypes.POINTER(ctypes.c_int)]
+    library.MagickGetException.restype = ctypes.c_char_p
 
-library.MagickClearException.argtypes = [ctypes.c_void_p]
+    library.MagickClearException.argtypes = [ctypes.c_void_p]
 
-library.MagickReadImageBlob.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
-                                        ctypes.c_size_t]
+    library.MagickReadImageBlob.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                            ctypes.c_size_t]
 
-library.MagickReadImage.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    library.MagickReadImage.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 
-library.MagickReadImageFile.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    library.MagickReadImageFile.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
-library.MagickGetImageFormat.argtypes = [ctypes.c_void_p]
-library.MagickGetImageFormat.restype = ctypes.c_char_p
+    library.MagickGetImageFormat.argtypes = [ctypes.c_void_p]
+    library.MagickGetImageFormat.restype = ctypes.c_char_p
 
-library.MagickSetImageFormat.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    library.MagickSetImageFormat.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 
-libmagick.MagickToMime.argtypes = [ctypes.c_char_p]
-libmagick.MagickToMime.restype = ctypes.POINTER(ctypes.c_char)
+    libmagick.MagickToMime.argtypes = [ctypes.c_char_p]
+    libmagick.MagickToMime.restype = ctypes.POINTER(ctypes.c_char)
 
-library.MagickGetImageSignature.argtypes = [ctypes.c_void_p]
-library.MagickGetImageSignature.restype = ctypes.c_char_p
+    library.MagickGetImageSignature.argtypes = [ctypes.c_void_p]
+    library.MagickGetImageSignature.restype = ctypes.c_char_p
 
-library.MagickGetImageBackgroundColor.argtypes = [ctypes.c_void_p,
-                                                  ctypes.c_void_p]
+    library.MagickGetImageBackgroundColor.argtypes = [ctypes.c_void_p,
+                                                      ctypes.c_void_p]
 
-library.MagickSetImageBackgroundColor.argtypes = [ctypes.c_void_p,
-                                                  ctypes.c_void_p]
+    library.MagickSetImageBackgroundColor.argtypes = [ctypes.c_void_p,
+                                                      ctypes.c_void_p]
 
-library.MagickGetImageBlob.argtypes = [ctypes.c_void_p,
-                                       ctypes.POINTER(ctypes.c_size_t)]
-library.MagickGetImageBlob.restype = ctypes.POINTER(ctypes.c_ubyte)
+    library.MagickGetImageBlob.argtypes = [ctypes.c_void_p,
+                                           ctypes.POINTER(ctypes.c_size_t)]
+    library.MagickGetImageBlob.restype = ctypes.POINTER(ctypes.c_ubyte)
 
-library.MagickWriteImage.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    library.MagickWriteImage.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 
-library.MagickWriteImageFile.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    library.MagickWriteImageFile.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
-library.MagickGetImageWidth.argtypes = [ctypes.c_void_p]
-library.MagickGetImageWidth.restype = ctypes.c_size_t
+    library.MagickGetImageWidth.argtypes = [ctypes.c_void_p]
+    library.MagickGetImageWidth.restype = ctypes.c_size_t
 
-library.MagickGetImageHeight.argtypes = [ctypes.c_void_p]
-library.MagickGetImageHeight.restype = ctypes.c_size_t
+    library.MagickGetImageHeight.argtypes = [ctypes.c_void_p]
+    library.MagickGetImageHeight.restype = ctypes.c_size_t
 
-library.MagickCropImage.argtypes = [ctypes.c_void_p, ctypes.c_size_t,
-                                    ctypes.c_size_t, ctypes.c_ssize_t,
-                                    ctypes.c_ssize_t]
+    library.MagickCropImage.argtypes = [ctypes.c_void_p, ctypes.c_size_t,
+                                        ctypes.c_size_t, ctypes.c_ssize_t,
+                                        ctypes.c_ssize_t]
 
-library.MagickResizeImage.argtypes = [ctypes.c_void_p, ctypes.c_size_t,
-                                      ctypes.c_size_t, ctypes.c_int,
-                                      ctypes.c_double]
+    library.MagickResizeImage.argtypes = [ctypes.c_void_p, ctypes.c_size_t,
+                                          ctypes.c_size_t, ctypes.c_int,
+                                          ctypes.c_double]
 
-library.MagickRotateImage.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
-                                      ctypes.c_double]
+    library.MagickRotateImage.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                          ctypes.c_double]
 
-library.MagickResetIterator.argtypes = [ctypes.c_void_p]
+    library.MagickResetIterator.argtypes = [ctypes.c_void_p]
 
-library.MagickIdentifyImage.argtypes = [ctypes.c_void_p]
-library.MagickIdentifyImage.restype = ctypes.c_char_p
+    library.MagickIdentifyImage.argtypes = [ctypes.c_void_p]
+    library.MagickIdentifyImage.restype = ctypes.c_char_p
 
-library.MagickRelinquishMemory.argtypes = [ctypes.c_void_p]
-library.MagickRelinquishMemory.restype = ctypes.c_void_p
+    library.MagickRelinquishMemory.argtypes = [ctypes.c_void_p]
+    library.MagickRelinquishMemory.restype = ctypes.c_void_p
 
-library.NewPixelIterator.argtypes = [ctypes.c_void_p]
-library.NewPixelIterator.restype = ctypes.c_void_p
+    library.NewPixelIterator.argtypes = [ctypes.c_void_p]
+    library.NewPixelIterator.restype = ctypes.c_void_p
 
-library.DestroyPixelIterator.argtypes = [ctypes.c_void_p]
-library.DestroyPixelIterator.restype = ctypes.c_void_p
+    library.DestroyPixelIterator.argtypes = [ctypes.c_void_p]
+    library.DestroyPixelIterator.restype = ctypes.c_void_p
 
-library.ClonePixelIterator.argtypes = [ctypes.c_void_p]
-library.ClonePixelIterator.restype = ctypes.c_void_p
+    library.ClonePixelIterator.argtypes = [ctypes.c_void_p]
+    library.ClonePixelIterator.restype = ctypes.c_void_p
 
-library.IsPixelIterator.argtypes = [ctypes.c_void_p]
+    library.IsPixelIterator.argtypes = [ctypes.c_void_p]
 
-library.PixelGetIteratorException.argtypes = [ctypes.c_void_p,
-                                              ctypes.POINTER(ctypes.c_int)]
-library.PixelGetIteratorException.restype = ctypes.c_char_p
+    library.PixelGetIteratorException.argtypes = [ctypes.c_void_p,
+                                                  ctypes.POINTER(ctypes.c_int)]
+    library.PixelGetIteratorException.restype = ctypes.c_char_p
 
-library.PixelClearIteratorException.argtypes = [ctypes.c_void_p]
+    library.PixelClearIteratorException.argtypes = [ctypes.c_void_p]
 
-library.PixelSetFirstIteratorRow.argtypes = [ctypes.c_void_p]
+    library.PixelSetFirstIteratorRow.argtypes = [ctypes.c_void_p]
 
-library.PixelSetIteratorRow.argtypes = [ctypes.c_void_p, ctypes.c_ssize_t]
+    library.PixelSetIteratorRow.argtypes = [ctypes.c_void_p, ctypes.c_ssize_t]
 
-library.PixelGetNextIteratorRow.argtypes = [ctypes.c_void_p,
-                                            ctypes.POINTER(ctypes.c_size_t)]
-library.PixelGetNextIteratorRow.restype = ctypes.POINTER(ctypes.c_void_p)
+    library.PixelGetNextIteratorRow.argtypes = [ctypes.c_void_p,
+                                                ctypes.POINTER(ctypes.c_size_t)]
+    library.PixelGetNextIteratorRow.restype = ctypes.POINTER(ctypes.c_void_p)
 
-library.NewPixelWand.restype = ctypes.c_void_p
+    library.NewPixelWand.restype = ctypes.c_void_p
 
-library.DestroyPixelWand.argtypes = [ctypes.c_void_p]
-library.DestroyPixelWand.restype = ctypes.c_void_p
+    library.DestroyPixelWand.argtypes = [ctypes.c_void_p]
+    library.DestroyPixelWand.restype = ctypes.c_void_p
 
-library.IsPixelWand.argtypes = [ctypes.c_void_p]
+    library.IsPixelWand.argtypes = [ctypes.c_void_p]
 
-library.PixelGetException.argtypes = [ctypes.c_void_p,
-                                      ctypes.POINTER(ctypes.c_int)]
-library.PixelGetException.restype = ctypes.c_char_p
+    library.PixelGetException.argtypes = [ctypes.c_void_p,
+                                          ctypes.POINTER(ctypes.c_int)]
+    library.PixelGetException.restype = ctypes.c_char_p
 
-library.PixelClearException.argtypes = [ctypes.c_void_p]
+    library.PixelClearException.argtypes = [ctypes.c_void_p]
 
-library.IsPixelWandSimilar.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
-                                       ctypes.c_double]
+    library.IsPixelWandSimilar.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                           ctypes.c_double]
 
-library.PixelGetMagickColor.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    library.PixelGetMagickColor.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
-library.PixelSetMagickColor.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    library.PixelSetMagickColor.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
-library.PixelSetColor.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    library.PixelSetColor.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
 
-library.PixelGetColorAsString.argtypes = [ctypes.c_void_p]
-library.PixelGetColorAsString.restype = ctypes.c_char_p
+    library.PixelGetColorAsString.argtypes = [ctypes.c_void_p]
+    library.PixelGetColorAsString.restype = ctypes.c_char_p
 
-library.PixelGetAlpha.argtypes = [ctypes.c_void_p]
-library.PixelGetAlpha.restype = ctypes.c_double
+    library.PixelGetAlpha.argtypes = [ctypes.c_void_p]
+    library.PixelGetAlpha.restype = ctypes.c_double
+except AttributeError:
+    raise ImportError("MagickWand shared library not found or incompatible")
 
 #: (:class:`ctypes.CDLL`) The C standard library.
 libc = None


### PR DESCRIPTION
If the MagickWand library isn't installed, wand triggers an AttributeError when it gets to this line:

``` python
library.NewMagickWand.restype = ctypes.c_void_p
```

This exception falls through all the way to the orignal import of wand, e.g.:

```
from wand.image import Image
```

This pull request catches the AttributeError and raises an ImportError instead, so this can be cleanly handled by the module that imports wand.
