### PR TITLE
Error in the initial example shown in the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Wand is a :mod:`ctypes`-based simple `MagickWand API`_ binding for Python. ::
             with img.clone() as i:
                 i.resize(int(i.width * r * 0.25), int(i.height * r * 0.25))
                 i.rotate(90 * r)
-                i.save('mona-lisa-{0}.png'.format(i))
+                i.save(filename='mona-lisa-{0}.png'.format(r))
                 display(i)
 
 You can install it from PyPI_ (and it requires MagickWand library):


### PR DESCRIPTION
Hello,
There seem to be two errors in the usage example on the index page of the docs.  
- r must be passed to format method of the file name instead of i
- the file name passed to the save method of the image object should be a keyword argument to function correctly

I've submitted a pull request to fix this.

Thanks,
Jeremy
