### PR TITLE
Added image.type property (mainly useful for format conversion)

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -223,6 +223,9 @@ try:
     library.MagickSetIteratorIndex.argtypes = [ctypes.c_void_p,
                                                ctypes.c_ssize_t]
 
+    library.MagickGetImageType.argtypes = [ctypes.c_void_p]
+    library.MagickGetImageType.restype = ctypes.c_int
+    
     library.MagickSetImageType.argtypes = [ctypes.c_void_p, ctypes.c_int]
 
     library.MagickEvaluateImageChannel.argtypes = [ctypes.c_void_p,

--- a/wand/image.py
+++ b/wand/image.py
@@ -21,7 +21,8 @@ from .color import Color
 from .resource import DestroyedResourceError, Resource
 
 
-__all__ = 'FILTER_TYPES', 'Image', 'Iterator', 'ClosedImageError'
+__all__ = 'FILTER_TYPES', 'COMPOSITE_OPS', 'CHANNELS', 'EVALUATE_OPS',\
+    'IMAGE_TYPES', 'Image', 'Iterator', 'ClosedImageError'
 
 
 #: (:class:`tuple`) The list of filter types.
@@ -519,6 +520,30 @@ class Image(Resource):
         r = library.MagickSetImageFormat(self.wand, fmt.strip().upper())
         if not r:
             raise ValueError(repr(fmt) + ' is unsupported format')
+        
+    @property
+    def type(self):
+        """(:class:`basestring`) The image type.
+
+        Defines image type as in wand.image.IMAGE_TYPES enumeration.
+        
+        It may raise :exc:`ValueError` when the type is unknown.
+ 
+        .. versionadded:: 0.1.11
+        """ 
+        image_type_index = library.MagickGetImageType(self.wand)        
+        if image_type_index < 0 or image_type_index >= len(IMAGE_TYPES):
+            raise ValueError('Unknown type')
+        return IMAGE_TYPES[image_type_index]
+    
+    @type.setter
+    def type(self, image_type):
+        if not isinstance(image_type, basestring) \
+            or image_type not in IMAGE_TYPES:
+            raise TypeError("Type value must be a string from IMAGE_TYPES"
+                            ', not ' + repr(image_type))
+        library.MagickSetImageType(
+            self.wand, IMAGE_TYPES.index(image_type))
 
     @property
     def compression_quality(self):


### PR DESCRIPTION
- Added signature for the MagickGetImageType

modified:   wand/image.py
- Exposed more tuples in _all_ defining low-level types.
- Implemented image.type() property, .e.g
  
  if img.type == 'grayscale':
      img.type = 'grayscalematte'
  assert img.type == 'grayscalematte'
