### PR TITLE
Added Image.read() and Image.clear()

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -164,6 +164,11 @@ try:
 
     library.MagickWriteImageFile.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
+    library.MagickGetImageResolution.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_double), ctypes.POINTER(ctypes.c_double)]
+
+    library.MagickSetImageResolution.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    library.MagickSetResolution.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+
     library.MagickGetImageWidth.argtypes = [ctypes.c_void_p]
     library.MagickGetImageWidth.restype = ctypes.c_size_t
 

--- a/wand/image.py
+++ b/wand/image.py
@@ -639,6 +639,26 @@ class Image(Resource):
         return library.MagickGetImageHeight(self.wand)
 
     @property
+    def resolution(self):
+        """(:class:`tuple`) Resolution of this image."""
+        x = ctypes.c_double()
+        y = ctypes.c_double()
+        r = library.MagickGetImageResolution(self.wand, x, y)
+        if not r:
+            self.raise_exception()
+        return int(x.value), int(y.value)
+
+    @resolution.setter
+    def resolution(self, geometry):
+        x, y = geometry
+        if self.size == (0,0):
+            r = library.MagickSetResolution(self.wand, x, y)
+        else:
+            r = library.MagickSetImageResolution(self.wand, x, y)
+        if not r:
+            self.raise_exception()
+
+    @property
     def size(self):
         """(:class:`tuple`) The pair of (:attr:`width`, :attr:`height`)."""
         return self.width, self.height

--- a/wandtests/image.py
+++ b/wandtests/image.py
@@ -220,6 +220,21 @@ def size():
 
 
 @tests.test
+def get_resolution():
+    """Gets image resolution."""
+    with Image(filename=asset('mona-lisa.jpg')) as img:
+        assert img.resolution == (72, 72)
+
+
+@tests.test
+def set_resolution():
+    """Sets image resolution."""
+    with Image(filename=asset('mona-lisa.jpg')) as img:
+        img.resolution = (100, 100)
+        assert img.resolution == (100, 100)
+
+
+@tests.test
 def get_units():
     """Gets the image resolution units."""
     with Image(filename=asset('beach.jpg')) as img:


### PR DESCRIPTION
I moved file reading related code into new method Image.read(). I also made few changes to allow calling Image without parameters. With new method Image.clear() it's now possible to reuse single Image object with multiple files:

``` python
img = Image()
img.read(filename='test1.png')
#do some operations
img.clear() # <- this clears existing wand
img.read(filename='test2.png')
```

It should now be possible to add functionality to close #28 without polluting Image constructor (I'm working on this). 
