### PR TITLE
Sequence improved api.

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -342,6 +342,26 @@ try:
 
     libmagick.GetMagickReleaseDate.argtypes = []
     libmagick.GetMagickReleaseDate.restype = ctypes.c_char_p
+
+
+    library.MagickAddImage.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    library.MagickRemoveImage.argtypes = [ctypes.c_void_p]
+    library.MagickGetNumberImages.argtypes = [ctypes.c_void_p]
+    library.MagickGetNumberImages.restype = ctypes.c_size_t
+    library.MagickGetIteratorIndex.argtypes = [ctypes.c_void_p]
+    library.MagickGetIteratorIndex.restype = ctypes.c_size_t
+    library.MagickSetIteratorIndex.argtypes = [ctypes.c_void_p, ctypes.c_ssize_t]
+    library.MagickGetImageType.argtypes = [ctypes.c_void_p]
+    library.MagickSetFirstIterator.argtypes = [ctypes.c_void_p]
+    library.MagickSetLastIterator.argtypes = [ctypes.c_void_p]
+    library.MagickResetIterator.argtypes = [ctypes.c_void_p]
+    library.MagickHasNextImage.argtypes = [ctypes.c_void_p]
+    library.MagickHasPreviousImage.argtypes = [ctypes.c_void_p]
+    library.MagickNextImage.argtypes = [ctypes.c_void_p]
+    library.MagickPreviousImage.argtypes = [ctypes.c_void_p]
+    library.MagickGetImageType.argtypes = [ctypes.c_void_p]
+
+
 except AttributeError:
     raise ImportError('MagickWand shared library not found or incompatible')
 

--- a/wand/image.py
+++ b/wand/image.py
@@ -611,6 +611,9 @@ class Image(Resource):
     def __hash__(self):
         return hash(self.signature)
 
+    def has_sequence(self):
+        return library.MagickGetNumberImages(self.wand) > 1
+
     @property
     def width(self):
         """(:class:`numbers.Integral`) The width of this image."""
@@ -658,7 +661,7 @@ class Image(Resource):
 
     @units.setter
     def units(self, units):
-        if not isinstance(units, basestring) or units not in UNIT_TYPES: 
+        if not isinstance(units, basestring) or units not in UNIT_TYPES:
             raise TypeError('Unit value must be a string from wand.images.'
                             'UNIT_TYPES, not ' + repr(units))
         r = library.MagickSetImageUnits(self.wand, UNIT_TYPES.index(units))

--- a/wand/sequence.py
+++ b/wand/sequence.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+from .api import library
+from .image import Image
+
+
+class Sequence(object):
+    """
+    MagickWand's image sequences manager.
+
+    :param image: An `Image` instance
+    :type image: :class:`Image`
+    """
+
+    def __init__(self, image, clone_by_default=True):
+        if not isinstance(image, Image):
+            raise TypeError('expected a wand.image.Image instance, '
+                            'not ' + repr(image))
+
+        if not image.has_sequence():
+            raise ValueError("Current image does not have secuence.")
+
+        self.image = image
+        self.clone = clone_by_default
+
+    def __len__(self):
+        return library.MagickGetNumberImages(self.image.wand)
+
+    def __getitem__(self, index):
+        if self.clone:
+            image = self.image.clone()
+        else:
+            image = self.image
+
+        library.MagickSetIteratorIndex(image.wand, index)
+        return image
+
+    def get_current_index(self):
+        return library.MagickGetIteratorIndex(self.image.wand)
+
+    def append(self, image):
+        self.insert(len(self) - 1, image)
+
+    def insert(self, index, image):
+        if not isinstance(image, Image):
+            raise TypeError('expected a wand.image.Image instance, '
+                            'not ' + repr(image))
+
+        if not 0 <= index < len(self):
+            raise TypeError('value could be between 0 and %s' % len(self))
+
+        current_index = self.get_current_index()
+        library.MagickSetIteratorIndex(self.image.wand, index)
+        library.MagickAddImage(self.image.wand, image.wand)
+        library.MagickSetIteratorIndex(self.image.wand, current_index)


### PR DESCRIPTION
This pull request is completely based on https://github.com/dahlia/wand/pull/39 but improved and more simple api.

The original implementation had a strange behavior ever since modified the current image and never knew that was the image that really were using.

This is a concept for see if it fits better with the main library.

Sample code:

Open a pdf

```
>>> from wand.image import Image
>>> from wand.sequence import Sequence
>>> i = Image(filename="../BBBBB.pdf")
>>> i.has_sequence()
True
```

Create sequence from image and access like a python list to sequence images.

```
>>> s = Sequence(i, clone_by_default=False)
>>> s[1].save(filename="/tmp/img.png")
>>> i.destroy()
```

Checks if current jpg image has sequence.

```
>>> i = Image(filename="tie01.jpg")
>>> i.has_sequence()
False
```

If we see that the result is as expected and convinces you, I will implement the corresponding tests.

Andrey
