### PR TITLE
Add '-6.Q16' suffix

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -85,7 +85,7 @@ def load_library():
 
     """
     tried_paths = []
-    for suffix in '', '-Q16', '-Q8':
+    for suffix in '', '-Q16', '-Q8', '-6.Q16':
         libwand_path, libmagick_path = find_library(suffix)
         if libwand_path is None or libmagick_path is None:
             continue


### PR DESCRIPTION
Because Arch Linux is using yet another suffix.

https://www.archlinux.org/packages/extra/i686/imagemagick/
