### PR TITLE
Fixed libMagickWand path in Darwin.

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -64,6 +64,9 @@ def find_library(suffix=''):
             libwand = ctypes.util.find_library('CORE_RL_wand_' + suffix)
         else:
             libwand = ctypes.util.find_library('MagickWand' + suffix)
+            if not libwand:
+                if system == 'Darwin':
+                    libwand = '/opt/local/lib/libMagickWand.dylib'
     if system == 'Windows':
         # On Windows, the API is split between two libs. On other platforms,
         # it's all contained in one.


### PR DESCRIPTION
I installed libMagickWand using MacPorts.
ctypes.util.find_library doesn't search in path /opt/local/lib/ because
LD_LIBRARY_PATH doesn't have.

How about set default path to '/lib/opt/local/lib' ?
