### PR TITLE
Fix inconsistency between ImageMagick versions when saving GIF image

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -249,7 +249,8 @@ try:
 
     library.MagickWriteImageFile.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
-    library.MagickWriteImages.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    library.MagickWriteImages.argtypes = [ctypes.c_void_p, ctypes.c_char_p,
+                                          ctypes.c_int]
 
     library.MagickWriteImagesFile.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 

--- a/wand/image.py
+++ b/wand/image.py
@@ -1802,7 +1802,7 @@ class Image(Resource):
                 raise TypeError('filename must be a string, not ' +
                                 repr(filename))
             if self.mimetype == 'image/gif':
-                r = library.MagickWriteImages(self.wand, filename)
+                r = library.MagickWriteImages(self.wand, filename, True)
             else:
                 r = library.MagickWriteImage(self.wand, filename)
             if not r:


### PR DESCRIPTION
`MagickWriteImages()` has the third parameter (`MagickBooleanType adjoin`), but it was not specified in ctypes binding.

It caused different behavior when saving an animated GIF image to the other GIF image on Ubuntu 12.10 and 13.04.
