### PR TITLE
Implement Color.__hash__()

### DIFF
--- a/tests/color_test.py
+++ b/tests/color_test.py
@@ -16,6 +16,16 @@ def test_not_equals():
     assert Color('rgba(0, 0, 0, 1)') != Color('rgba(1, 1, 1, 1)')
 
 
+def test_hash():
+    """Hash test."""
+    assert hash(Color('#fff')) == hash(Color('#ffffff')) == \
+        hash(Color('white'))
+    assert hash(Color('#000')) == hash(Color('#000000')) == \
+        hash(Color('black'))
+    assert hash(Color('rgba(0, 0, 0, 0))')) == hash(Color('rgba(0, 0, 0, 0))'))
+    assert hash(Color('rgba(0, 0, 0, 0))')) == hash(Color('rgba(1, 1, 1, 0))'))
+
+
 def test_red():
     assert Color('black').red == 0
     assert Color('red').red == 1

--- a/wand/color.py
+++ b/wand/color.py
@@ -135,6 +135,11 @@ class Color(Resource):
     def __ne__(self, other):
         return not (self == other)
 
+    def __hash__(self):
+        if self.alpha:
+            return hash(self.string)
+        return hash(None)
+
     @property
     def red(self):
         """(:class:`numbers.Real`) Red, from 0.0 to 1.0."""


### PR DESCRIPTION
Since alpha zero colors (e.g. 'rgba(1, 1, 1, 0)') are always equal
but may have different string representations, `hash(None)` is returned
for such case.
