### PR TITLE
(WIP) #116 CentOS compatibility

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -609,8 +609,11 @@ try:
     library.DrawSetTextEncoding.argtypes = [ctypes.c_void_p,
                                             ctypes.c_char_p]
 
-    library.DrawSetTextInterlineSpacing.argtypes = [ctypes.c_void_p,
-                                                    ctypes.c_double]
+    try:
+        library.DrawSetTextInterlineSpacing.argtypes = [ctypes.c_void_p,
+                                                        ctypes.c_double]
+    except AttributeError:
+        library.DrawSetTextInterlineSpacing = None
 
     library.DrawSetTextInterwordSpacing.argtypes = [ctypes.c_void_p,
                                                     ctypes.c_double]
@@ -642,8 +645,11 @@ try:
     library.DrawGetTextEncoding.argtypes = [ctypes.c_void_p]
     library.DrawGetTextEncoding.restype = ctypes.c_char_p
 
-    library.DrawGetTextInterlineSpacing.argtypes = [ctypes.c_void_p]
-    library.DrawGetTextInterlineSpacing.restype = ctypes.c_double
+    try:
+        library.DrawGetTextInterlineSpacing.argtypes = [ctypes.c_void_p]
+        library.DrawGetTextInterlineSpacing.restype = ctypes.c_double
+    except AttributeError:
+        library.DrawGetTextInterlineSpacing = None
 
     library.DrawGetTextInterwordSpacing.argtypes = [ctypes.c_void_p]
     library.DrawGetTextInterwordSpacing.restype = ctypes.c_double

--- a/wand/drawing.py
+++ b/wand/drawing.py
@@ -15,6 +15,7 @@ from .color import Color
 from .compat import binary, string_type, text, text_type, xrange
 from .image import Image
 from .resource import Resource
+from .exceptions import WandLibraryVersionError
 
 __all__ = ('FONT_METRICS_ATTRIBUTES', 'TEXT_ALIGN_TYPES',
            'TEXT_DECORATION_TYPES', 'GRAVITY_TYPES', 'Drawing', 'FontMetrics')
@@ -237,10 +238,14 @@ class Drawing(Resource):
         It also can be set.
 
         """
+        if library.DrawGetTextInterlineSpacing is None:
+            raise WandLibraryVersionError('The installed version of ImageMagick does not support this feature')
         return library.DrawGetTextInterlineSpacing(self.resource)
 
     @text_interline_spacing.setter
     def text_interline_spacing(self, spacing):
+        if library.DrawSetTextInterlineSpacing is None:
+            raise WandLibraryVersionError('The installed version of ImageMagick does not support this feature')
         if not isinstance(spacing, numbers.Real):
             raise TypeError('expeted a numbers.Real, but got ' + repr(spacing))
         library.DrawSetTextInterlineSpacing(self.resource, spacing)

--- a/wand/exceptions.py
+++ b/wand/exceptions.py
@@ -29,6 +29,9 @@ class WandError(WandException):
 class WandFatalError(WandException):
     """Base class for Wand-related fatal errors."""
 
+class WandLibraryVersionError(WandException):
+    """Base class for Wand-related ImageMagick version errors."""
+
 
 #: (:class:`list`) A list of error/warning domains, these descriptions and
 #: codes. The form of elements is like: (domain name, description, codes).


### PR DESCRIPTION
Related to issue #116.

@dahlia, not sure that what I did follows the best practices, but we have been using this version on our dev machines for some time now and it works without problem.

Changelist:
- Made DrawSetTextInterlineSpacing and DrawGetTextInterlineSpacing optional
- Added exception in drawing api when trying to use those features when they are not available
- Added specific exception class for library versions issues
