### PR TITLE
Color init with string: use Color resource management for setup

### DIFF
--- a/wand/color.py
+++ b/wand/color.py
@@ -74,15 +74,17 @@ class Color(Resource):
         if (string is None and raw is None or
             string is not None and raw is not None):
             raise TypeError('expected one argument')
-        elif raw is None:
-            pixel = library.NewPixelWand()
-            library.PixelSetColor(pixel, binary(string))
-            raw = ctypes.create_string_buffer(
+
+        self.allocated = 0
+        if raw is None:
+            self.raw = ctypes.create_string_buffer(
                 ctypes.sizeof(MagickPixelPacket)
             )
-            library.PixelGetMagickColor(pixel, raw)
-        self.raw = raw
-        self.allocated = 0
+            with self:
+                library.PixelSetColor(self.resource, binary(string))
+                library.PixelGetMagickColor(self.resource, self.raw)
+        else:
+            self.raw = raw
 
     def __getinitargs__(self):
         return self.string, None


### PR DESCRIPTION
When initializing a Color by string, a PixelWand is leaked every time.

This can be easily verified by calling

`for i in xrange(5000):
    orange = wand.color.Color('orange')
    del orange`

and watching the memory footprint of the Python process increase (with any system tool available).

Fix: freeing the PixelWand in **init**. I thought it might be best to use the resource management that's already in place instead of adding the DestroyPixelWand explicitly.

No test is added, because I don't know about a cross-platform builtin Python module to measure memory.

All provided tests still pass.
