### PR TITLE
Image save to stream truncates data

### DIFF
--- a/wand/image.py
+++ b/wand/image.py
@@ -1913,6 +1913,7 @@ class Image(BaseImage):
             if isinstance(file, file_types) and hasattr(libc, 'fdopen'):
                 fd = libc.fdopen(file.fileno(), file.mode)
                 r = library.MagickWriteImageFile(self.wand, fd)
+                libc.fflush(fd)
                 if not r:
                     self.raise_exception()
             else:


### PR DESCRIPTION
Noticed images were being truncated. This only happens when using the file parameter to image.save. A simple buffer flush fixes the issue.
