### PR TITLE
Allow setting jpeg:sampling-factor option

### DIFF
--- a/wand/image.py
+++ b/wand/image.py
@@ -340,7 +340,7 @@ ORIENTATION_TYPES = ('undefined', 'top_left', 'top_right', 'bottom_right',
 #: (:class:`collections.Set`) The set of available :attr:`~BaseImage.options`.
 #:
 #: .. versionadded:: 0.3.0
-OPTIONS = frozenset(['fill'])
+OPTIONS = frozenset(('fill', 'jpeg:sampling-factor'))
 
 
 def manipulative(function):


### PR DESCRIPTION
This option is important for JPEG optimizations fine-tuning.
