### PR TITLE
Fix searching of MagickWand library with HDR support enabled

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -8,6 +8,7 @@
 """
 import ctypes
 import ctypes.util
+import itertools
 import os
 import os.path
 import sys
@@ -84,7 +85,10 @@ def load_library():
 
     """
     tried_paths = []
-    for suffix in '', '-Q16', '-Q8', '-6.Q16':
+    versions = ('', '-Q16', '-Q8', '-6.Q16', )
+    options = ('HDRI', )
+    combinations = itertools.product(versions, options)
+    for suffix in (version + option for version, option in combinations):
         libwand_path, libmagick_path = find_library(suffix)
         if libwand_path is None or libmagick_path is None:
             continue


### PR DESCRIPTION
Hi!

Currently, `wand` not able for load libraries with name like this - `libMagickWand-6.Q16HDRI.so`.

I add support to `wand` for custom options in name.

There is pull request #140, but i think this is more general solution.
