### PR TITLE
Fix undefined attribute when conditional falls through

### DIFF
--- a/wand/image.py
+++ b/wand/image.py
@@ -701,7 +701,7 @@ class BaseImage(Resource):
         :const:`ORIENTATION_TYPES` list.  It also can be set.
 
         .. versionadded:: 0.3.0
-        
+
         """
         orientation_index = library.MagickGetImageOrientation(self.wand)
         return ORIENTATION_TYPES[text(orientation_index)]
@@ -1223,7 +1223,7 @@ class BaseImage(Resource):
             library.MagickSetSize(self.wand, width, height)
             if not r:
                 self.raise_exception()
-                
+
     @manipulative
     def sample(self, width=None, height=None):
         """Resizes the image by sampling the pixels.  It's basically quicker
@@ -1673,7 +1673,7 @@ class BaseImage(Resource):
 
         :raises exceptions.ValueError:
            when one or more arguments are invalid
-        
+
         .. versionadded:: 0.3.4
 
         """
@@ -1958,6 +1958,7 @@ class Image(BaseImage):
         .. versionadded:: 0.3.0
 
         """
+        r = None
         # Resolution must be set after image reading.
         if resolution is not None:
             if (isinstance(resolution, collections.Sequence) and


### PR DESCRIPTION
Trivial change to `wand.image.Image.read`, where an `UnboundLocalError` can be raised on line 1993 due to `r` not being defined due to neither `blob is not None` nor `filename is not None` conditionals being met. Fixed by added `r = None` definition at the top of the method. I did not find another case of this in this file; in each case there was an `else`.
