### PR TITLE
Clarify docs for y coordinate of Drawing.text

### DIFF
--- a/wand/drawing.py
+++ b/wand/drawing.py
@@ -498,7 +498,7 @@ class Drawing(Resource):
 
         :param x: the left offset where to start writing a text
         :type x: :class:`numbers.Integral`
-        :param y: the top offset where to start writing a text
+        :param y: the baseline where to start writing text
         :type y: :class:`numbers.Integral`
         :param body: the body string to write
         :type body: :class:`basestring`


### PR DESCRIPTION
I clarified what was meant in the documentation for `Drawing.text`; let me know if you think it should be worded differently!
