### PR TITLE
HTTPResponse is not guaranteed to have mode

### DIFF
--- a/wand/image.py
+++ b/wand/image.py
@@ -2024,7 +2024,7 @@ class Image(BaseImage):
                                 'integer of the same x/y')
         if file is not None:
             if (isinstance(file, file_types) and
-                hasattr(libc, 'fdopen')):
+                    hasattr(libc, 'fdopen') and hasattr(file, 'mode')):
                 fd = libc.fdopen(file.fileno(), file.mode)
                 r = library.MagickReadImageFile(self.wand, fd)
             elif not callable(getattr(file, 'read', None)):


### PR DESCRIPTION
Please see https://github.com/crosspop/sqlalchemy-imageattach/issues/25 for details.

This seems to work for me.

Some relevant info on the topic of `HTTPResponse` and its _file likeiness_:
http://bugs.python.org/issue19154
