### PR TITLE
Adds file.seek(0)

### DIFF
--- a/wand/image.py
+++ b/wand/image.py
@@ -2082,6 +2082,7 @@ class Image(BaseImage):
                 raise TypeError('resolution must be a (x, y) pair or an '
                                 'integer of the same x/y')
         if file is not None:
+            file.seek(0)
             if (isinstance(file, file_types) and
                     hasattr(libc, 'fdopen') and hasattr(file, 'mode')):
                 fd = libc.fdopen(file.fileno(), file.mode)


### PR DESCRIPTION
In a situation where the file has been peeked/read, if fed in again, it will raise a 
`zero-length blob not permitted `' @ error/blob.c/BlobToImage/333 (Magick::ImageMagickError)`