### PR TITLE
Implement query helpers

### DIFF
--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -1,11 +1,12 @@
 import datetime
 import numbers
 import re
+from py.test import mark
 
 from wand.version import (MAGICK_VERSION, MAGICK_VERSION_INFO,
                           MAGICK_VERSION_NUMBER, MAGICK_RELEASE_DATE,
-                          MAGICK_RELEASE_DATE_STRING, QUANTUM_DEPTH)
-
+                          MAGICK_RELEASE_DATE_STRING, QUANTUM_DEPTH,
+                          configure_options, fonts, formats)
 
 def test_version():
     """Test version strings."""
@@ -24,3 +25,19 @@ def test_version():
 def test_quantum_depth():
     """QUANTUM_DEPTH must be one of 8, 16, 32, or 64."""
     assert QUANTUM_DEPTH in (8, 16, 32, 64)
+
+
+def test_configure_options():
+    assert 'RELEASE_DATE' in configure_options('RELEASE_DATE')
+
+
+def test_fonts():
+    font_list = fonts()
+    mark.skipif(not font_list, reason='Fonts not configured on system')
+    first_font = font_list[0]
+    assert first_font in fonts('*{}*'.format(first_font[1:-1]))
+
+
+def test_formats():
+    xc = 'XC'
+    assert formats(xc) == [xc]

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -35,7 +35,8 @@ def test_fonts():
     font_list = fonts()
     mark.skipif(not font_list, reason='Fonts not configured on system')
     first_font = font_list[0]
-    assert first_font in fonts('*{}*'.format(first_font[1:-1]))
+    first_font_part = first_font[1:-1]
+    assert first_font in fonts('*{0}*'.format(first_font_part))
 
 
 def test_formats():

--- a/wand/api.py
+++ b/wand/api.py
@@ -1139,10 +1139,25 @@ try:
 
     library.MagickEqualizeImage.argtypes = [ctypes.c_void_p]
 
+    library.MagickQueryConfigureOption.argtypes = [ctypes.c_char_p]
+    library.MagickQueryConfigureOption.restype = c_magick_char_p
+
+    library.MagickQueryConfigureOptions.argtypes = [ctypes.c_char_p,
+                                                    ctypes.POINTER(ctypes.c_size_t)]
+    library.MagickQueryConfigureOptions.restype = ctypes.POINTER(c_magick_char_p)
+
     library.MagickQueryFontMetrics.argtypes = [ctypes.c_void_p,
                                                ctypes.c_void_p,
                                                ctypes.c_char_p]
     library.MagickQueryFontMetrics.restype = ctypes.POINTER(ctypes.c_double)
+
+    library.MagickQueryFonts.argtypes = [ctypes.c_char_p,
+                                         ctypes.POINTER(ctypes.c_size_t)]
+    library.MagickQueryFonts.restype = ctypes.POINTER(c_magick_char_p)
+
+    library.MagickQueryFormats.argtypes = [ctypes.c_char_p,
+                                           ctypes.POINTER(ctypes.c_size_t)]
+    library.MagickQueryFormats.restype = ctypes.POINTER(c_magick_char_p)
 
     library.MagickQueryMultilineFontMetrics.argtypes = [ctypes.c_void_p,
                                                         ctypes.c_void_p,

--- a/wand/version.py
+++ b/wand/version.py
@@ -10,6 +10,17 @@ You can find the current version in the command line interface:
    $ python -m wand.version --verbose
    Wand 0.0.0
    ImageMagick 6.7.7-6 2012-06-03 Q16 http://www.imagemagick.org
+   $ python -m wand.version --config | grep CC | cut -d : -f 2
+   gcc -std=gnu99 -std=gnu99
+   $ python -m wand.version --fonts | grep Helvetica
+   Helvetica
+   Helvetica-Bold
+   Helvetica-Light
+   Helvetica-Narrow
+   Helvetica-Oblique
+   $ python -m wand.version --formats | grep CMYK
+   CMYK
+   CMYKA
 
 .. versionadded:: 0.2.0
    The command line interface.
@@ -17,6 +28,10 @@ You can find the current version in the command line interface:
 .. versionadded:: 0.2.2
    The ``--verbose``/``-v`` option which also prints ImageMagick library
    version for CLI.
+
+.. versionadded:: 0.4.1
+   The ``--fonts``, ``--formats``, & ``--config`` option allows printing
+   additional information about ImageMagick library.
 
 """
 from __future__ import print_function
@@ -27,16 +42,16 @@ import re
 import sys
 
 try:
-    from .api import libmagick
+    from .api import libmagick, library
 except ImportError:
     libmagick = None
-from .compat import text
+from .compat import binary, string_type, text
 
 
 __all__ = ('VERSION', 'VERSION_INFO', 'MAGICK_VERSION',
            'MAGICK_VERSION_INFO', 'MAGICK_VERSION_NUMBER',
            'MAGICK_RELEASE_DATE', 'MAGICK_RELEASE_DATE_STRING',
-           'QUANTUM_DEPTH')
+           'QUANTUM_DEPTH', 'configure_options', 'fonts', 'formats')
 
 #: (:class:`tuple`) The version tuple e.g. ``(0, 1, 2)``.
 #:
@@ -104,6 +119,110 @@ if libmagick:
 
     del c_magick_version, _match, c_quantum_depth
 
+
+
+def configure_options(pattern='*'):
+    """
+    Queries ImageMagick library for configurations options given at compile-time.
+
+    Example: Find where the ImageMagick documents are installed::
+
+        >>> from wand.version import configure_options
+        >>> configure_options('DOC*')
+        {'DOCUMENTATION_PATH': '/usr/local/share/doc/ImageMagick-6'}
+
+    :param pattern: A term to filter queries against. Supports wildcard '*'
+                    characters. Default patterns '*' for all options.
+    :type pattern: :class:`basestring`
+    :returns: Directory of configuration options matching given pattern
+    :rtype: :class:`collections.defaultdict`
+    """
+    if not isinstance(pattern, string_type):
+        raise TypeError('pattern must be a string, not ' + repr(pattern))
+    pattern_p = ctypes.create_string_buffer(binary(pattern))
+    number_configs = ctypes.c_size_t(0)
+    configs = {}
+    configs_p = library.MagickQueryConfigureOptions(pattern_p,
+                                                    ctypes.byref(number_configs))
+    cursor = 0
+    while cursor < number_configs.value:
+        config = configs_p[cursor].value
+        value = library.MagickQueryConfigureOption(config)
+        configs[text(config)] = text(value.value)
+        cursor += 1
+    return configs
+
+
+def fonts(pattern='*'):
+    """
+    Queries ImageMagick library for available fonts.
+
+    Available fonts can be configured by defining `types.xml`,
+    `type-ghostscript.xml`, or `type-windows.xml`.
+    Use :func:`wand.version.configure_options` to locate system search path,
+    and `resources <http://www.imagemagick.org/script/resources.php>`_
+    article for defining xml file.
+
+    Example: List all bold Helvetica fonts::
+
+        >>> from wand.version import fonts
+        >>> fonts('*Helvetica*Bold*')
+        ['Helvetica-Bold', 'Helvetica-Bold-Oblique', 'Helvetica-BoldOblique',
+         'Helvetica-Narrow-Bold', 'Helvetica-Narrow-BoldOblique']
+
+
+    :param pattern: A term to filter queries against. Supports wildcard '*'
+                    characters. Default patterns '*' for all options.
+    :type pattern: :class:`basestring`
+    :returns: Sequence of matching fonts
+    :rtype: :class:`collections.Sequence`
+    """
+    if not isinstance(pattern, string_type):
+        raise TypeError('pattern must be a string, not ' + repr(pattern))
+    pattern_p = ctypes.create_string_buffer(binary(pattern))
+    number_fonts = ctypes.c_size_t(0)
+    fonts = []
+    fonts_p = library.MagickQueryFonts(pattern_p,
+                                       ctypes.byref(number_fonts))
+    cursor = 0
+    while cursor < number_fonts.value:
+        font = fonts_p[cursor].value
+        fonts.append(text(font))
+        cursor += 1
+    return fonts
+
+
+def formats(pattern='*'):
+    """
+    Queries ImageMagick library for supported formats.
+
+    Example: List supported PNG formats::
+
+        >>> from wand.version import formats
+        >>> formats('PNG*')
+        ['PNG', 'PNG00', 'PNG8', 'PNG24', 'PNG32', 'PNG48', 'PNG64']
+
+
+    :param pattern: A term to filter formats against. Supports wildcards '*'
+                    characters. Default pattern '*' for all formats.
+    :type pattern: :class:`basestring`
+    :returns: Sequence of matching formats
+    :rtype: :class:`collections.Sequence`
+    """
+    if not isinstance(pattern, string_type):
+        raise TypeError('pattern must be a string, not ' + repr(pattern))
+    pattern_p = ctypes.create_string_buffer(binary(pattern))
+    number_formats = ctypes.c_size_t(0)
+    formats = []
+    formats_p = library.MagickQueryFormats(pattern_p,
+                                           ctypes.byref(number_formats))
+    cursor = 0
+    while cursor < number_formats.value:
+        value = formats_p[cursor].value
+        formats.append(text(value))
+        cursor += 1
+    return formats
+
 if __doc__ is not None:
     __doc__ = __doc__.replace('0.0.0', VERSION)
 
@@ -118,5 +237,15 @@ if __name__ == '__main__':
             print(MAGICK_VERSION)
         except NameError:
             pass
+    elif '--fonts' in options:
+        for font in fonts():
+            print(font)
+    elif '--formats' in options:
+        for supported_format in formats():
+            print(supported_format)
+    elif '--config' in options:
+        config_options = configure_options()
+        for key in config_options:
+            print('{:24s}: {}'.format(key, config_options[key]))
     else:
         print(VERSION)

--- a/wand/version.py
+++ b/wand/version.py
@@ -120,10 +120,10 @@ if libmagick:
     del c_magick_version, _match, c_quantum_depth
 
 
-
 def configure_options(pattern='*'):
     """
-    Queries ImageMagick library for configurations options given at compile-time.
+    Queries ImageMagick library for configurations options given at
+    compile-time.
 
     Example: Find where the ImageMagick documents are installed::
 
@@ -140,12 +140,12 @@ def configure_options(pattern='*'):
     if not isinstance(pattern, string_type):
         raise TypeError('pattern must be a string, not ' + repr(pattern))
     pattern_p = ctypes.create_string_buffer(binary(pattern))
-    number_configs = ctypes.c_size_t(0)
+    config_count = ctypes.c_size_t(0)
     configs = {}
     configs_p = library.MagickQueryConfigureOptions(pattern_p,
-                                                    ctypes.byref(number_configs))
+                                                    ctypes.byref(config_count))
     cursor = 0
-    while cursor < number_configs.value:
+    while cursor < config_count.value:
         config = configs_p[cursor].value
         value = library.MagickQueryConfigureOption(config)
         configs[text(config)] = text(value.value)


### PR DESCRIPTION
This pull request resolves #120. 

Functions `configure_options`, `fonts`, and `formats` have been added to `wand.version`. Each function accepts a string pattern to query against, and supports `*` as wildcard character.

Helper CLI flags have been added to `wand.version` for additional usability.

```bash
# Find CC
$ python -m wand.version --config | grep CC | cut -d : -f 2
gcc -std=gnu99 -std=gnu99

# List Helvetica variations
$ python -m wand.version --fonts | grep Helvetica
Helvetica
Helvetica-Bold
Helvetica-Light
Helvetica-Narrow
Helvetica-Oblique

# Check if CMYK is supported
$ python -m wand.version --formats | grep CMYK
CMYK
CMYKA
```