### PR TITLE
Replaced libc.free calls with MagickRelinquishMemory

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,20 @@ Wand Changelog
 0.4 series
 ~~~~~~~~~~
 
+.. _changelog-0.4.1:
+
+Version 0.4.1
+-------------
+
+- Additional query functions have been added to :mod:`wand.version` API. [:issue:`120`]
+
+  - Added :func:`configure_options() <wand.version.configure_options>` function.
+  - Added :func:`fonts() <wand.version.fonts>` function.
+  - Added :func:`formats() <wand.version.formats>` function.
+
+- Fixed Windows memory-deallocate errors on :mod:`wand.drawing` API. [:issue:`226` by Eric McConville]
+
+
 .. _changelog-0.4.0:
 
 Version 0.4.0

--- a/tests/drawing_test.py
+++ b/tests/drawing_test.py
@@ -42,7 +42,7 @@ def test_set_get_font(fx_wand, fx_asset):
     assert fx_wand.font == str(fx_asset.join('League_Gothic.otf'))
 
 def test_set_get_font_family(fx_wand):
-    assert fx_wand.font_family == ''
+    assert fx_wand.font_family is None
     fx_wand.font_family = 'sans-serif'
     assert fx_wand.font_family == 'sans-serif'
 

--- a/wand/api.py
+++ b/wand/api.py
@@ -790,7 +790,7 @@ try:
                                            ctypes.c_void_p] # PixelWand color
 
     library.DrawGetClipPath.argtypes = [ctypes.c_void_p]
-    library.DrawGetClipPath.restype = ctypes.c_void_p
+    library.DrawGetClipPath.restype = c_magick_char_p
 
     library.DrawGetClipRule.argtypes = [ctypes.c_void_p]
     library.DrawGetClipRule.restype = ctypes.c_uint
@@ -839,10 +839,10 @@ try:
     library.DrawGetStrokeWidth.restype = ctypes.c_double
 
     library.DrawGetFont.argtypes = [ctypes.c_void_p]
-    library.DrawGetFont.restype = ctypes.c_void_p
+    library.DrawGetFont.restype = c_magick_char_p
 
     library.DrawGetFontFamily.argtypes = [ctypes.c_void_p]
-    library.DrawGetFontFamily.restype = ctypes.c_void_p
+    library.DrawGetFontFamily.restype = c_magick_char_p
 
     library.DrawGetFontResolution.argtypes = [ctypes.c_void_p, #wand
                                ctypes.POINTER(ctypes.c_double), # x
@@ -877,7 +877,7 @@ try:
         library.DrawGetTextDirection = None
 
     library.DrawGetTextEncoding.argtypes = [ctypes.c_void_p]
-    library.DrawGetTextEncoding.restype = ctypes.c_void_p
+    library.DrawGetTextEncoding.restype = c_magick_char_p
 
     try:
         library.DrawGetTextInterlineSpacing.argtypes = [ctypes.c_void_p]
@@ -895,7 +895,7 @@ try:
                                               ctypes.c_void_p]
 
     library.DrawGetVectorGraphics.argtypes = [ctypes.c_void_p]
-    library.DrawGetVectorGraphics.restype = ctypes.c_void_p
+    library.DrawGetVectorGraphics.restype = c_magick_char_p
 
     library.DrawSetGravity.argtypes = [ctypes.c_void_p,
                                        ctypes.c_int]

--- a/wand/drawing.py
+++ b/wand/drawing.py
@@ -10,7 +10,7 @@ import collections
 import ctypes
 import numbers
 
-from .api import library, libc, MagickPixelPacket, PointInfo, AffineMatrix
+from .api import library, MagickPixelPacket, PointInfo, AffineMatrix
 from .color import Color
 from .compat import binary, string_type, text, text_type, xrange
 from .image import Image, COMPOSITE_OPERATORS
@@ -219,7 +219,8 @@ class Drawing(Resource):
         """(:class:`basestring`) The current clip path. It also can be set.
 
         .. versionadded:: 0.4.0
-
+        .. versionchanged: 0.4.1
+           Safely release allocated memory with MagickRelinquishMemory instead of libc.free.
         """
         clip_path_p = library.DrawGetClipPath(self.resource)
         return text(clip_path_p.value)
@@ -274,7 +275,11 @@ class Drawing(Resource):
 
     @property
     def font(self):
-        """(:class:`basestring`) The current font name.  It also can be set."""
+        """(:class:`basestring`) The current font name.  It also can be set.
+
+        .. versionchanged: 0.4.1
+           Safely release allocated memory with MagickRelinquishMemory instead of libc.free.
+        """
         font_p = library.DrawGetFont(self.resource)
         return text(font_p.value)
 
@@ -289,6 +294,8 @@ class Drawing(Resource):
         """(:class:`basestring`) The current font family. It also can be set.
 
         .. versionadded:: 0.4.0
+        .. versionchanged: 0.4.1
+           Safely release allocated memory with MagickRelinquishMemory instead of libc.free.
         """
         font_family_p = library.DrawGetFontFamily(self.resource)
         return text(font_family_p.value)
@@ -510,6 +517,8 @@ class Drawing(Resource):
         It also can be set.
 
         .. versionadded:: 0.4.0
+        .. versionchanged: 0.4.1
+           Safely release allocated memory with MagickRelinquishMemory instead of libc.free.
         """
         number_elements = ctypes.c_size_t(0)
         dash_array_p = library.DrawGetStrokeDashArray(
@@ -724,6 +733,8 @@ class Drawing(Resource):
         """(:class:`basestring`) The internally used text encoding setting.
         Although it also can be set, but it's not encouraged.
 
+        .. versionchanged: 0.4.1
+           Safely release allocated memory with MagickRelinquishMemory instead of libc.free.
         """
         text_encoding_p = library.DrawGetTextEncoding(self.resource)
         return text(text_encoding_p.value)
@@ -820,7 +831,8 @@ class Drawing(Resource):
         to the default state.
 
         .. versionadded:: 0.4.0
-
+        .. versionchanged: 0.4.1
+           Safely release allocated memory with MagickRelinquishMemory instead of libc.free.
         """
         vector_graphics_p = library.DrawGetVectorGraphics(self.resource)
         return '<wand>' + text(vector_graphics_p.value) + '</wand>'


### PR DESCRIPTION
Release 0.4.0 introduced `libc`  module & `@leaky_string` decorator to manage memory allocated by MagickWand library under `wand.drawing`. However Windows user my experience undefined behavior, if not invalid address access errors, when calling methods that rely on `libc.free`. This pull request refactors `wand.drawing` API to leverage existing `wand.api.c_magcik_char_p` & `library.MagickRelinquishMemory`; thus, returns the responsibility of memory deallaction back to the MagickWand library.