### PR TITLE
Add support for MagickLevelImage method.

### DIFF
--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1249,36 +1249,58 @@ def test_normalize_channel(fx_asset):
             assert getattr(img[-1, -1], c) == getattr(right_bottom, c)
 
 def test_level_default(fx_asset):
-    im_qr = pow(2, QUANTUM_DEPTH)
     with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
         # Adjust the levels to make this image entirely black
-        img.level(im_qr, 1.0, im_qr)
+        img.level(1, 1)
         with img[0, 0] as dark:
             assert dark.red_int8 <= dark.green_int8 <= dark.blue_int8 <= 0
         with img[0, -1] as dark:
             assert dark.red_int8 <= dark.green_int8 <= dark.blue_int8 <= 0
     with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
         # Adjust the levels to make this image entirely white
-        img.level(0, 1.0, 0)
+        img.level(0, 0)
         with img[0, 0] as light:
             assert light.red_int8 >= light.green_int8 >= light.blue_int8 >= 255
         with img[0, -1] as light:
             assert light.red_int8 >= light.green_int8 >= light.blue_int8 >= 255
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        # Adjust the image's gamma to darken its midtones
+        img.level(0, 1, 0.5)
+        with img[0, len(img) // 2] as light:
+            assert light.red_int8 <= light.green_int8 <= light.blue_int8 <= 65
+            assert light.red_int8 >= light.green_int8 >= light.blue_int8 >= 60
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        # Adjust the image's gamma to lighten its midtones
+        img.level(0, 1, 2.5)
+        with img[0, len(img) // 2] as light:
+            assert light.red_int8 <= light.green_int8 <= light.blue_int8 <= 195
+            assert light.red_int8 >= light.green_int8 >= light.blue_int8 >= 190
 
 def test_level_channel(fx_asset):
-    im_qr = pow(2, QUANTUM_DEPTH)
     for chan in ('red', 'green', 'blue'):
         c = chan + '_int8'
         with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
             # Adjust each channel level to make it entirely black
-            img.level(im_qr, 1.0, im_qr, chan)
+            img.level(1, 1, channel=chan)
             assert(getattr(img[0, 0], c) <= 0)
             assert(getattr(img[0, -1], c) <= 0)
         with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
             # Adjust each channel level to make it entirely white
-            img.level(0, 1.0, 0, chan)
+            img.level(0, 0, channel=chan)
             assert(getattr(img[0, 0], c) >= 255)
             assert(getattr(img[0, -1], c) >= 255)
+        with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+            # Adjust each channel's gamma to darken its midtones
+            img.level(0, 1, 0.5, chan)
+            with img[0, len(img) // 2] as light:
+                assert(getattr(light, c) <= 65)
+                assert(getattr(light, c) >= 60)
+        with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+            # Adjust each channel's gamma to lighten its midtones
+            img.level(0, 1, 2.5, chan)
+            with img[0, len(img) // 2] as light:
+                assert(getattr(light, c) >= 190)
+                assert(getattr(light, c) <= 195)
 
 def test_equalize(fx_asset):
     with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:

--- a/wand/api.py
+++ b/wand/api.py
@@ -473,6 +473,14 @@ try:
 
     library.MagickSetImageType.argtypes = [ctypes.c_void_p, ctypes.c_int]
 
+    library.MagickLevelImage.argtypes = [
+        ctypes.c_void_p, ctypes.c_double, ctypes.c_double, ctypes.c_double
+    ]
+
+    library.MagickLevelImageChannel.argtypes = [
+        ctypes.c_void_p, ctypes.c_int, ctypes.c_double, ctypes.c_double, ctypes.c_double
+    ]
+
     library.MagickEvaluateImageChannel.argtypes = [ctypes.c_void_p,
                                                    ctypes.c_int,
                                                    ctypes.c_int,

--- a/wand/api.py
+++ b/wand/api.py
@@ -473,13 +473,16 @@ try:
 
     library.MagickSetImageType.argtypes = [ctypes.c_void_p, ctypes.c_int]
 
-    library.MagickLevelImage.argtypes = [
-        ctypes.c_void_p, ctypes.c_double, ctypes.c_double, ctypes.c_double
-    ]
+    library.MagickLevelImage.argtypes = [ctypes.c_void_p,
+                                         ctypes.c_double,
+                                         ctypes.c_double,
+                                         ctypes.c_double]
 
-    library.MagickLevelImageChannel.argtypes = [
-        ctypes.c_void_p, ctypes.c_int, ctypes.c_double, ctypes.c_double, ctypes.c_double
-    ]
+    library.MagickLevelImageChannel.argtypes = [ctypes.c_void_p,
+                                                ctypes.c_int,
+                                                ctypes.c_double,
+                                                ctypes.c_double,
+                                                ctypes.c_double]
 
     library.MagickEvaluateImageChannel.argtypes = [ctypes.c_void_p,
                                                    ctypes.c_int,

--- a/wand/image.py
+++ b/wand/image.py
@@ -2127,21 +2127,40 @@ class Image(BaseImage):
         """
         library.ClearMagickWand(self.wand)
 
-    def level(self, black, gamma, white, channel=None):
-        """Adjusts the levels of an image by scaling the colors falling between
-        specified white and black points to the full available quantum range.
+    def level(self, black=0.0, white=1.0, gamma=1.0, channel=None):
+        """Adjusts the levels of an image by scaling the colors falling
+        between specified black and white points to the full available
+        quantum range.
+
+        :param black: Black point, as a percentage of the system's quantum
+                      range. Defaults to 0.
+        :type black: :class:`numbers.Real`
+        :param white: White point, as a percentage of the system's quantum
+                      range. Defaults to 1.0.
+        :type white: :class:`numbers.Real`
+        :param gamma: Optional gamma adjustment. Values > 1.0 lighten the
+                      image's midtones while values < 1.0 darken them.
+        :type gamma: :class:`numbers.Real`
+        :param channel: The channel type. Available values can be found
+                        in the :const:`CHANNELS` mapping. If ``None``,
+                        normalize all channels.
+        :type channel: :class:`basestring`
 
         .. versionadded:: 0.4.1
+
         """
+
+        bp = float(self.quantum_range * black)
+        wp = float(self.quantum_range * white)
         if channel:
             try:
                 ch_const = CHANNELS[channel]
             except KeyError:
                 raise ValueError(repr(channel) + ' is an invalid channel type'
                                  '; see wand.image.CHANNELS dictionary')
-            r = library.MagickLevelImageChannel(self.wand, ch_const, black, gamma, white)
+            r = library.MagickLevelImageChannel(self.wand, ch_const, bp, gamma, wp)
         else:
-            r = library.MagickLevelImage(self.wand, black, gamma, white)
+            r = library.MagickLevelImage(self.wand, bp, gamma, wp)
 
         if not r:
             self.raise_exception()

--- a/wand/image.py
+++ b/wand/image.py
@@ -2127,6 +2127,25 @@ class Image(BaseImage):
         """
         library.ClearMagickWand(self.wand)
 
+    def level(self, black, gamma, white, channel=None):
+        """Adjusts the levels of an image by scaling the colors falling between
+        specified white and black points to the full available quantum range.
+
+        .. versionadded:: 0.4.1
+        """
+        if channel:
+            try:
+                ch_const = CHANNELS[channel]
+            except KeyError:
+                raise ValueError(repr(channel) + ' is an invalid channel type'
+                                 '; see wand.image.CHANNELS dictionary')
+            r = library.MagickLevelImageChannel(self.wand, ch_const, black, gamma, white)
+        else:
+            r = library.MagickLevelImage(self.wand, black, gamma, white)
+
+        if not r:
+            self.raise_exception()
+
     @property
     def format(self):
         """(:class:`basestring`) The image format.


### PR DESCRIPTION
Add support for the MagickLevelImage method, which allows users to adjust an image's white and black levels. Based on the work from saga64 in https://github.com/dahlia/wand/pull/167, but with additional error handling and test cases.