### PR TITLE
Proposed fix for issue #237 - Sequence not clearing from memory

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,8 @@ Version 0.4.1
   - Render RGB :class:`Color <wand.color.Color>` preview.
   - Display each frame in image :class:`Sequence <wand.sequence.Sequence>`.
 
+- Fixed memory-leak when accessing images constructed in
+  :class:`Image.sequence[] <wand.sequence.Sequence>`. [:issue:`237` by Eric McConville]
 - Fixed Windows memory-deallocate errors on :mod:`wand.drawing` API. [:issue:`226` by Eric McConville]
 
 

--- a/wand/api.py
+++ b/wand/api.py
@@ -589,6 +589,9 @@ try:
     libmagick.DestroyExceptionInfo.argtypes = [ctypes.c_void_p]
     libmagick.DestroyExceptionInfo.restype = ctypes.c_void_p
 
+    libmagick.DestroyImage.argtypes = [ctypes.c_void_p]
+    libmagick.DestroyImage.restype = ctypes.c_void_p
+
     library.MagickGetSize.argtypes = [ctypes.c_void_p,
                                       ctypes.POINTER(ctypes.c_uint),
                                       ctypes.POINTER(ctypes.c_uint)]

--- a/wand/sequence.py
+++ b/wand/sequence.py
@@ -128,6 +128,7 @@ class Sequence(ImageProperty, collections.MutableSequence):
         single_image = libmagick.CloneImages(image, binary(str(index)), exc)
         libmagick.DestroyExceptionInfo(exc)
         single_wand = library.NewMagickWandFromImage(single_image)
+        single_image = libmagick.DestroyImage(single_image)
         library.MagickSetIteratorIndex(wand, tmp_idx)
         instance = SingleImage(single_wand, self.image, image)
         self.instances[index] = instance


### PR DESCRIPTION
Opening PR for issue #237. After reviewing [NewMagickWandFromImage source code](http://www.imagemagick.org/api/MagickWand/magick-wand_8c_source.html#l01115), cloned image instances are safe to destroy after use. 

Pending testing, verification, and doc updates, this solution can be merged for a greater testing audience.