### PR TITLE
Evaluate & Color stretch

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,7 @@ Version 0.4.1
 - Added :meth:`Image.auto_orient() <wand.image.Image.auto_orient>` that fixes orientation by checking EXIF tags
 - Added :meth:`Image.transverse() <wand.image.Image.transverse>` transverse (MagickTransverseImage)
 - Added :meth:`Image.transpose() <wand.image.Image.transpose>` transpose (MagickTransposeImage)
+- Added :meth:`Image.evaluate() <wand.image.BaseImage.evaluate>` method.
 - Added :meth:`Image.frame() <wand.image.BaseImage.frame>` method.
 - Added :meth:`Image.function() <wand.image.BaseImage.function>` method.
 - Added :meth:`Image.fx() <wand.image.BaseImage.fx>` expression method.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,9 @@ Version 0.4.1
 - Added :attr:`Image.matte_color <wand.image.BaseImage.matte_color>` property.
 - Added :attr:`Image.virtual_pixel <wand.image.BaseImage.virtual_pixel>` property.
 - Added :meth:`Image.distort() <wand.image.BaseImage.distort>` method.
+- Added :meth:`Image.contrast_stretch() <wand.image.Image.contrast_stretch>` method.
+- Added :meth:`Image.gamma() <wand.image.Image.gamma>` method.
+- Added :meth:`Image.linear_stretch() <wand.image.Image.linear_stretch>` method.
 - Additional support for :attr:`Image.alpha_channel <wand.image.BaseImage.alpha_channel>`.
 - Additional query functions have been added to :mod:`wand.version` API. [:issue:`120`]
 

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1281,6 +1281,82 @@ def test_threshold_channel(fx_asset):
                     red.green_int8 == red.blue_int8 == 0)
 
 
+def test_contrast_stretch(fx_asset):
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        img.contrast_stretch(0.15)
+        with img[0, 10] as left_top:
+            assert left_top.red_int8 == 255
+        with img[0, 90] as left_bottom:
+            assert left_bottom.red_int8 == 0
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        img.contrast_stretch(0.15, channel='red')
+        with img[0, 10] as left_top:
+            assert left_top.red_int8 == 255
+        with img[0, 90] as left_bottom:
+            assert left_bottom.red_int8 == 0
+
+
+def test_contrast_stretch_user_error(fx_asset):
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        with raises(TypeError):
+            img.contrast_stretch('NaN')
+        with raises(TypeError):
+            img.contrast_stretch(0.1, 'NaN')
+        with raises(ValueError):
+            img.contrast_stretch(0.1, channel='Not a channel')
+
+
+def test_gamma(fx_asset):
+    # Value under 1.0 is darker, and above 1.0 is lighter
+    middle_point = 75, 50
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        with img.clone() as lighter:
+            lighter.gamma(1.5)
+            assert img[middle_point].red < lighter[middle_point].red
+        with img.clone() as darker:
+            darker.gamma(0.5)
+            assert img[middle_point].red > darker[middle_point].red
+
+
+def test_gamma_channel(fx_asset):
+    # Value under 1.0 is darker, and above 1.0 is lighter
+    middle_point = 75, 50
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        with img.clone() as lighter:
+            lighter.gamma(1.5, channel='red')
+            assert img[middle_point].red < lighter[middle_point].red
+        with img.clone() as darker:
+            darker.gamma(0.5, channel='red')
+            assert img[middle_point].red > darker[middle_point].red
+
+
+def test_gamma_user_error(fx_asset):
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        with raises(TypeError):
+            img.gamma('NaN;')
+        with raises(ValueError):
+            img.gamma(0.0, 'no channel')
+
+
+def test_linear_stretch(fx_asset):
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        img.linear_stretch(black_point=0.15,
+                           white_point=0.15)
+        with img[0, 10] as left_top:
+            assert left_top.red_int8 == 255
+        with img[0, 90] as left_bottom:
+            assert left_bottom.red_int8 == 0
+
+
+def test_linear_stretch_user_error(fx_asset):
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        with raises(TypeError):
+            img.linear_stretch(white_point='NaN',
+                               black_point=0.5)
+        with raises(TypeError):
+            img.linear_stretch(white_point=0.5,
+                               black_point='NaN')
+
 def test_normalize_default(display, fx_asset):
     with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
         display(img)

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1413,6 +1413,31 @@ def test_equalize(fx_asset):
             assert dark.red_int8 <= dark.green_int8 <= dark.blue_int8 <= 5
 
 
+def test_evaluate(fx_asset):
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        with img.clone() as percent_img:
+            fifty_percent = percent_img.quantum_range * 0.5
+            percent_img.evaluate('set', fifty_percent)
+            with percent_img[10, 10] as gray:
+                assert abs(gray.red - Color('gray50').red) < 0.01
+        with img.clone() as literal_img:
+            literal_img.evaluate('divide', 2, channel='red')
+            with img[0, 0] as org_color:
+                expected_color = (img[0, 0].red_int8 * 0.5)
+                with literal_img[0, 0] as actual_color:
+                    assert abs(expected_color - actual_color.red_int8) < 1
+
+
+def test_evaluate_user_error(fx_asset):
+    with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
+        with raises(ValueError):
+            img.evaluate(operator='Nothing')
+        with raises(TypeError):
+            img.evaluate(operator='set', value='NaN')
+        with raises(ValueError):
+            img.evaluate(operator='set', value=1.0, channel='Not a channel')
+
+
 def test_flip(fx_asset):
     with Image(filename=str(fx_asset.join('beach.jpg'))) as img:
         with img.clone() as flipped:

--- a/wand/api.py
+++ b/wand/api.py
@@ -513,10 +513,27 @@ try:
 
     library.MagickSetImageType.argtypes = [ctypes.c_void_p, ctypes.c_int]
 
+    library.MagickEvaluateImage.argtypes = [ctypes.c_void_p,
+                                            ctypes.c_int,
+                                            ctypes.c_double]
+
     library.MagickEvaluateImageChannel.argtypes = [ctypes.c_void_p,
                                                    ctypes.c_int,
                                                    ctypes.c_int,
                                                    ctypes.c_double]
+
+    library.MagickContrastImage.argtypes = [ctypes.c_void_p,  # wand
+                                            ctypes.c_double,  # black
+                                            ctypes.c_double]  # white
+
+    library.MagickContrastImageChannel.argtypes = [ctypes.c_void_p,  # wand
+                                                   ctypes.c_int,     # channel
+                                                   ctypes.c_double,  # black
+                                                   ctypes.c_double]  # white
+
+    library.MagickLinearStretchImage.argtypes = [ctypes.c_void_p,  # wand
+                                                 ctypes.c_double,  # black
+                                                 ctypes.c_double]  # white
 
     library.MagickCompositeImage.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
                                              ctypes.c_int, ctypes.c_ssize_t,

--- a/wand/api.py
+++ b/wand/api.py
@@ -522,14 +522,14 @@ try:
                                                    ctypes.c_int,
                                                    ctypes.c_double]
 
-    library.MagickContrastImage.argtypes = [ctypes.c_void_p,  # wand
-                                            ctypes.c_double,  # black
-                                            ctypes.c_double]  # white
-
-    library.MagickContrastImageChannel.argtypes = [ctypes.c_void_p,  # wand
-                                                   ctypes.c_int,     # channel
+    library.MagickContrastStretchImage.argtypes = [ctypes.c_void_p,  # wand
                                                    ctypes.c_double,  # black
                                                    ctypes.c_double]  # white
+
+    library.MagickContrastStretchImageChannel.argtypes = [ctypes.c_void_p,  # wand
+                                                          ctypes.c_int,     # channel
+                                                          ctypes.c_double,  # black
+                                                          ctypes.c_double]  # white
 
     library.MagickLinearStretchImage.argtypes = [ctypes.c_void_p,  # wand
                                                  ctypes.c_double,  # black

--- a/wand/api.py
+++ b/wand/api.py
@@ -531,6 +531,14 @@ try:
                                                           ctypes.c_double,  # black
                                                           ctypes.c_double]  # white
 
+    library.MagickGammaImage.argtypes = [ctypes.c_void_p,
+                                         ctypes.c_double]
+
+    library.MagickGammaImageChannel.argtypes = [ctypes.c_void_p,
+                                                ctypes.c_int,
+                                                ctypes.c_double]
+
+
     library.MagickLinearStretchImage.argtypes = [ctypes.c_void_p,  # wand
                                                  ctypes.c_double,  # black
                                                  ctypes.c_double]  # white

--- a/wand/image.py
+++ b/wand/image.py
@@ -2835,14 +2835,14 @@ class Image(BaseImage):
         self.raise_exception()
 
     @manipulative
-    def gamma(self, gamma_point, channel=None):
+    def gamma(self, adjustment_value, channel=None):
         """Gamma correct image.
 
         Specific color channels can be correct individual. Typical values
         range between 0.8 and 2.3.
 
-        :param gamma_point: Value to adjust gamma level
-        :type gamma_point: :class:`numbers.Real`
+        :param adjustment_value: Value to adjust gamma level
+        :type adjustment_value: :class:`numbers.Real`
         :param channel: Optional channel to apply gamma correction
         :type channel: :class:`basestring`
         :raises: :exc:`TypeError` if ``gamma_point`` is not a :class:`numbers.Real`
@@ -2850,14 +2850,14 @@ class Image(BaseImage):
 
         .. versionadded::0.4.1
         """
-        if not isinstance(gamma_point, numbers.Real):
-            raise TypeError('expecting float, not ' + repr(gamma_point))
+        if not isinstance(adjustment_value, numbers.Real):
+            raise TypeError('expecting float, not ' + repr(adjustment_value))
         if channel in CHANNELS:
             library.MagickGammaImageChannel(self.wand,
                                             CHANNELS[channel],
-                                            gamma_point)
+                                            adjustment_value)
         elif channel is None:
-            library.MagickGammaImage(self.wand, gamma_point)
+            library.MagickGammaImage(self.wand, adjustment_value)
         else:
             raise ValueError(repr(channel) + ' is an invalid channel type'
                              '; see wand.image.CHANNELS dictionary')

--- a/wand/image.py
+++ b/wand/image.py
@@ -2803,13 +2803,19 @@ class Image(BaseImage):
             self.raise_exception()
 
     @manipulative
-    def contrast_stretch(self, black_point=0.0, white_point=1.0, channel=None):
+    def contrast_stretch(self, black_point=0.0, white_point=None, channel=None):
         """Enhance contrast of image by adjusting the span of the available
         colors.
 
+        If only ``black_point`` is given, match the CLI behavior by assuming the
+        ``white_point`` has the same delta percentage off the top. E.g. contrast
+        stretch of 15% is calculated as ``black_point`` = 0.15 and
+        ``white_point`` = 0.85.
+
         :param black_point: Black point between 0.0 and 1.0. Default 0.0
         :type black_point: :class:`numbers.Real`
-        :param white_point: White point between 0.0 and 1.0. Default 1.0
+        :param white_point: White point between 0.0 and 1.0. Default value of
+                            1.0 minus ``black_point``.
         :type white_point: :class:`numbers.Real`
         :param channel: Color channel to apply contrast stretch. Default all
         :type channel: :class:`basestring`
@@ -2818,6 +2824,10 @@ class Image(BaseImage):
         .. versionadded:: 0.4.1
         """
         contrast_range = float(self.width * self.height)
+        # If only black-point is given, match CLI behavior by
+        # calculating white point
+        if white_point is None:
+            white_point = 1.0 - black_point
         black_point *= contrast_range
         white_point *= contrast_range
         if channel in CHANNELS:

--- a/wand/image.py
+++ b/wand/image.py
@@ -254,7 +254,7 @@ EVALUATE_OPS = ('undefined', 'add', 'and', 'divide', 'leftshift', 'max',
                 'thresholdwhite', 'gaussiannoise', 'impulsenoise',
                 'laplaciannoise', 'multiplicativenoise', 'poissonnoise',
                 'uniformnoise', 'cosine', 'sine', 'addmodulus', 'mean',
-                'abs', 'exponential', 'median', 'sum')
+                'abs', 'exponential', 'median', 'sum', 'rootmeansquare')
 
 #: (:class:`tuple`) The list of colorspaces.
 #:
@@ -1713,6 +1713,27 @@ class BaseImage(Resource):
                     self.raise_exception()
                 if reset_coords:
                     self.reset_coords()
+
+    @manipulative
+    def evaluate(self, operator=None, value=0.0, channel=None):
+        """Apply arithmetic, relational, or logical expression to an image.
+        .. versionadded:: 0.4.1
+        """
+        if operator not in EVALUATE_OPS:
+            raise ValueError('expected value from EVALUATE_OPS, not ' + repr(operator))
+        if not isinstance(value, numbers.Real):
+            raise TypeError('value must be real number, not ' + repr(value))
+        if channel:
+            if channel not in CHANNELS:
+                raise ValueError('expected value from CHANNELS, not ' + repr(channel))
+            library.MagickEvaluateImageChannel(self.wand,
+                                               CHANNELS[channel],
+                                               EVALUATE_OPS.index(operator),
+                                               value)
+        else:
+            library.MagickEvaluateImage(self.wand,
+                                        EVALUATE_OPS.index(operator), value)
+        self.raise_exception()
 
     @manipulative
     def flip(self):

--- a/wand/image.py
+++ b/wand/image.py
@@ -2823,11 +2823,15 @@ class Image(BaseImage):
 
         .. versionadded:: 0.4.1
         """
-        contrast_range = float(self.width * self.height)
+        if not isinstance(black_point, numbers.Real):
+            raise TypeError('expecting float, not ' + repr(black_point))
+        if white_point is not None and not isinstance(white_point, numbers.Real):
+            raise TypeError('expecting float, not ' + repr(white_point))
         # If only black-point is given, match CLI behavior by
         # calculating white point
         if white_point is None:
             white_point = 1.0 - black_point
+        contrast_range = float(self.width * self.height)
         black_point *= contrast_range
         white_point *= contrast_range
         if channel in CHANNELS:
@@ -2884,10 +2888,14 @@ class Image(BaseImage):
 
         .. versionadded:: 0.4.1
         """
-        quantum_range = self.quantum_range
+        if not isinstance(black_point, numbers.Real):
+            raise TypeError('expecting float, not ' + repr(black_point))
+        if not isinstance(white_point, numbers.Real):
+            raise TypeError('expecting float, not ' + repr(white_point))
+        linear_range = float(self.width * self.height)
         library.MagickLinearStretchImage(self.wand,
-                                         quantum_range * black_point,
-                                         quantum_range * white_point)
+                                         linear_range * black_point,
+                                         linear_range * white_point)
 
     def normalize(self, channel=None):
         """Normalize color channels.

--- a/wand/image.py
+++ b/wand/image.py
@@ -1728,7 +1728,8 @@ class BaseImage(Resource):
     def evaluate(self, operator=None, value=0.0, channel=None):
         """Apply arithmetic, relational, or logical expression to an image.
 
-        Percent values must be pre-calculated against image's Quantum Range::
+        Percent values must be calculated against the quantum range of the
+        image::
 
             fifty_percent = img.quantum_range * 0.5
             img.evaluate(operator='set', value=fifty_percent)

--- a/wand/image.py
+++ b/wand/image.py
@@ -2802,7 +2802,21 @@ class Image(BaseImage):
         if not result:
             self.raise_exception()
 
+    @manipulative
     def contrast_stretch(self, black_point=0.0, white_point=1.0, channel=None):
+        """Enhance contrast of image by adjusting the span of the available
+        colors.
+
+        :param black_point: Black point between 0.0 and 1.0. Default 0.0
+        :type black_point: :class:`numbers.Real`
+        :param white_point: White point between 0.0 and 1.0. Default 1.0
+        :type white_point: :class:`numbers.Real`
+        :param channel: Color channel to apply contrast stretch. Default all
+        :type channel: :class:`basestring`
+        :raises: :exc:`ValueError` if ``channel`` is not in :const:`CHANNELS`
+
+        .. versionadded:: 0.4.1
+        """
         contrast_range = float(self.width * self.height)
         black_point *= contrast_range
         white_point *= contrast_range
@@ -2820,7 +2834,46 @@ class Image(BaseImage):
                              '; see wand.image.CHANNELS dictionary')
         self.raise_exception()
 
+    @manipulative
+    def gamma(self, gamma_point, channel=None):
+        """Gamma correct image.
+
+        Specific color channels can be correct individual. Typical values
+        range between 0.8 and 2.3.
+
+        :param gamma_point: Value to adjust gamma level
+        :type gamma_point: :class:`numbers.Real`
+        :param channel: Optional channel to apply gamma correction
+        :type channel: :class:`basestring`
+        :raises: :exc:`TypeError` if ``gamma_point`` is not a :class:`numbers.Real`
+        :raises: :exc:`ValueError` if ``channel`` is not in :const:`CHANNELS`
+
+        .. versionadded::0.4.1
+        """
+        if not isinstance(gamma_point, numbers.Real):
+            raise TypeError('expecting float, not ' + repr(gamma_point))
+        if channel in CHANNELS:
+            library.MagickGammaImageChannel(self.wand,
+                                            CHANNELS[channel],
+                                            gamma_point)
+        elif channel is None:
+            library.MagickGammaImage(self.wand, gamma_point)
+        else:
+            raise ValueError(repr(channel) + ' is an invalid channel type'
+                             '; see wand.image.CHANNELS dictionary')
+        self.raise_exception()
+
+    @manipulative
     def linear_stretch(self, black_point=0.0, white_point=1.0):
+        """Enhance saturation intensity of an image.
+
+        :param black_point: Black point between 0.0 and 1.0. Default 0.0
+        :type black_point: :class:`numbers.Real`
+        :param white_point: White point between 0.0 and 1.0. Default 1.0
+        :type white_point: :class:`numbers.Real`
+
+        .. versionadded:: 0.4.1
+        """
         quantum_range = self.quantum_range
         library.MagickLinearStretchImage(self.wand,
                                          quantum_range * black_point,

--- a/wand/image.py
+++ b/wand/image.py
@@ -1727,6 +1727,22 @@ class BaseImage(Resource):
     @manipulative
     def evaluate(self, operator=None, value=0.0, channel=None):
         """Apply arithmetic, relational, or logical expression to an image.
+
+        Percent values must be pre-calculated against image's Quantum Range::
+
+            fifty_percent = img.quantum_range * 0.5
+            img.evaluate(operator='set', value=fifty_percent)
+
+        :param operator: Type of operation to calculate
+        :type operator: :const:`EVALUATE_OPS`
+        :param value: Number to calculate with ``operator``
+        :type value: :class:`numbers.Real`
+        :param channel: Optional channel to apply operation on.
+        :type channel: :const:`CHANNELS`
+        :raises TypeError: When ``value`` is not numeric.
+        :raises ValueError: When ``operator``, or ``channel`` are not defined
+                            in constants.
+
         .. versionadded:: 0.4.1
         """
         if operator not in EVALUATE_OPS:

--- a/wand/image.py
+++ b/wand/image.py
@@ -2829,8 +2829,8 @@ class Image(BaseImage):
         :param white_point: White point between 0.0 and 1.0. Default value of
                             1.0 minus ``black_point``.
         :type white_point: :class:`numbers.Real`
-        :param channel: Color channel to apply contrast stretch. Default all
-        :type channel: :class:`basestring`
+        :param channel: Optional color channel to apply contrast stretch.
+        :type channel: :const:`CHANNELS`
         :raises: :exc:`ValueError` if ``channel`` is not in :const:`CHANNELS`
 
         .. versionadded:: 0.4.1
@@ -2874,7 +2874,7 @@ class Image(BaseImage):
         :raises: :exc:`TypeError` if ``gamma_point`` is not a :class:`numbers.Real`
         :raises: :exc:`ValueError` if ``channel`` is not in :const:`CHANNELS`
 
-        .. versionadded::0.4.1
+        .. versionadded:: 0.4.1
         """
         if not isinstance(adjustment_value, numbers.Real):
             raise TypeError('expecting float, not ' + repr(adjustment_value))

--- a/wand/image.py
+++ b/wand/image.py
@@ -1205,7 +1205,6 @@ class BaseImage(Resource):
         self.raise_exception()
 
 
-
     @manipulative
     def crop(self, left=0, top=0, right=None, bottom=None,
              width=None, height=None, reset_coords=True,
@@ -2802,6 +2801,30 @@ class Image(BaseImage):
                                                width, height)
         if not result:
             self.raise_exception()
+
+    def contrast_stretch(self, black_point=0.0, white_point=1.0, channel=None):
+        contrast_range = float(self.width * self.height)
+        black_point *= contrast_range
+        white_point *= contrast_range
+        if channel in CHANNELS:
+            library.MagickContrastStretchImageChannel(self.wand,
+                                                      CHANNELS[channel],
+                                                      black_point,
+                                                      white_point)
+        elif channel is None:
+            library.MagickContrastStretchImage(self.wand,
+                                               black_point,
+                                               white_point)
+        else:
+            raise ValueError(repr(channel) + ' is an invalid channel type'
+                             '; see wand.image.CHANNELS dictionary')
+        self.raise_exception()
+
+    def linear_stretch(self, black_point=0.0, white_point=1.0):
+        quantum_range = self.quantum_range
+        library.MagickLinearStretchImage(self.wand,
+                                         quantum_range * black_point,
+                                         quantum_range * white_point)
 
     def normalize(self, channel=None):
         """Normalize color channels.


### PR DESCRIPTION
This pull-request introduces the following methods.

 - [x] Image.evaluate
 - [x] Image.contrast_stretch
 - [x] Image.gamma
 - [x] Image.linear_stretch

### Why?
Methods listed above complement the previous body of work, and position the 0.4.1 patch release to focus on common photography tasks.

What's missing is `Image.level` (#235), and general documentation / usage / examples. 

I'll merge & clean-up PU #235 shortly, and than focus on docs + outstanding bugs reports.