### PR TITLE
Add .so filename for FreeBSD

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -86,7 +86,7 @@ def load_library():
 
     """
     tried_paths = []
-    versions = ('', '-Q16', '-Q8', '-6.Q16')
+    versions = ('', '-6', '-Q16', '-Q8', '-6.Q16')
     options = ('', 'HDRI')
     combinations = itertools.product(versions, options)
     for suffix in (version + option for version, option in combinations):


### PR DESCRIPTION
Original error:
```
>>> from wand.image import Image
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/wand/image.py", line 20, in <module>
    from .api import MagickPixelPacket, libc, libmagick, library
  File "/usr/local/lib/python2.7/site-packages/wand/api.py", line 176, in <module>
    'Try to install:\n  ' + msg)
ImportError: MagickWand shared library not found.
You probably had not installed ImageMagick library.
Try to install:
  pkg_add -r
>>> sys.modules['wand._api'].load_library()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/wand/api.py", line 107, in load_library
    raise IOError('cannot find library; tried paths: ' + repr(tried_paths))
IOError: cannot find library; tried paths: ['libMagickWand.so.5']
```

On FreeBSD 10.1 `libMagickWand` is located at `/usr/local/lib/libMagickWand-6.so`.