### PR TITLE
Adaptation for MSYS2

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -51,7 +51,7 @@ def library_paths():
     libwand = None
     libmagick = None
     versions = '', '-6', '-Q16', '-Q8', '-6.Q16'
-    options = '', 'HDRI'
+    options = '', 'HDRI', 'HDRI-2'
     system = platform.system()
     magick_home = os.environ.get('MAGICK_HOME')
     magick_path = lambda dir: os.path.join(magick_home, *dir)
@@ -64,6 +64,9 @@ def library_paths():
                 libwand = 'CORE_RL_wand_{0}.dll'.format(suffix),
                 libmagick = 'CORE_RL_magick_{0}.dll'.format(suffix),
                 yield magick_path(libwand), magick_path(libmagick)
+                libwand = 'libMagickWand{0}.dll'.format(suffix),
+                libmagick = 'libMagickCore{0}.dll'.format(suffix),
+                yield magick_path(libwand), magick_path(libmagick)
             elif system == 'Darwin':
                 libwand = 'lib', 'libMagickWand{0}.dylib'.format(suffix),
                 yield magick_path(libwand), magick_path(libwand)
@@ -73,6 +76,9 @@ def library_paths():
         if system == 'Windows':
             libwand = ctypes.util.find_library('CORE_RL_wand_' + suffix)
             libmagick = ctypes.util.find_library('CORE_RL_magick_' + suffix)
+            yield libwand, libmagick
+            libwand = ctypes.util.find_library('libMagickWand' + suffix)
+            libmagick = ctypes.util.find_library('libMagickCore' + suffix)
             yield libwand, libmagick
         else:
             libwand = ctypes.util.find_library('MagickWand' + suffix)


### PR DESCRIPTION
[MSYS2](http://msys2.github.io/) is a POSIX-complaint environment for Windows. It provides PE binaries built from MinGW-w64 compilers, through pacman which MSYS2 team successfully ported.

I installed `mingw-w64-i686-python3`, `mingw-w64-i686-pip3`, `mingw-w64-imagemagick` using MSYS2 pacman, then run `pip3 install wand`. It was successful but `import wand.image` did not work. It was because ImageMagick binaries were installed as `/mingw32/bin/libMagick(Core|Wand)-6.Q16HDRI-2.dll` (with no `$MAGICK_HOME`) in my case. As current Wand searches for `CORE_RL_(wand|magick)_<suffix>(.dll)` on Windows and `libMagickWand<suffix>(.so)` for almost others, Wand couldn't find the binaries in my case.

This PR includes two commit of changeset over `wand/api.py`. The former one changes the structure of ImageMagick library probing procedure. `find_library()`, now renamed `library_paths()`, became a generator function that iterates for possible library paths. Then `load_library()` checks if each path is loadable, via `ctypes.CDLL()`. The latter one, finally appends more example for library path that succeeds in case of MSYS2.

Manually tested in:
- Windows 7 Professional K SP1, x86, MSYS2(MINGW32 shell), Python 3.4
- Ubuntu 14.04.2 kernel 3.13.0-48-generic, x86_64, Python2.7

Thanks to @dahlia who provided proper feedback for me to write these changes.