### PR TITLE
Fix libc.dylib import on El Capitan

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -1395,7 +1395,7 @@ if platform.system() == 'Windows':
         libc = ctypes.CDLL(msvcrt)
 else:
     if platform.system() == 'Darwin':
-        libc = ctypes.cdll.LoadLibrary('libc.dylib')
+        libc = ctypes.cdll.LoadLibrary('/usr/lib/libc.dylib')
     elif platform.system() == 'FreeBSD':
         libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('c'))
     else:


### PR DESCRIPTION
El Capitan SIP protection causes the LoadLibrary call to fail unless an absolute path is supplied for libc.dylib.