### PR TITLE
`wand.image.Image.caption` raises TypeError with better description

### DIFF
--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1246,6 +1246,17 @@ def test_caption(fx_asset):
         )
 
 
+def test_caption_without_font(fx_asset):
+    with Image(width=144, height=192, background=Color('#1e50a2')) as img:
+        with raises(TypeError):
+            img.caption(
+                'Test message',
+                left=5, top=144,
+                width=134, height=20,
+                gravity='center'
+            )
+
+
 def test_setfont(fx_asset):
     with Image(width=144, height=192, background=Color('#1e50a2')) as img:
         font = Font(

--- a/wand/image.py
+++ b/wand/image.py
@@ -916,9 +916,14 @@ class BaseImage(Resource):
             width = self.width - left
         if height is None:
             height = self.height - top
+        if not font:
+            try:
+                font = self.font
+            except TypeError:
+                raise TypeError('font must be specified or existing in image')
         with Image() as textboard:
             library.MagickSetSize(textboard.wand, width, height)
-            textboard.font = font or self.font
+            textboard.font = font
             textboard.gravity = gravity or self.gravity
             with Color('transparent') as background_color:
                 library.MagickSetBackgroundColor(textboard.wand,


### PR DESCRIPTION
Previously, calling caption on image without font raises error inside font
"path must be a string, not None." which is not very helpful for
`caption` funtion itself. Now users will get better idea what is going
wrong.