### PR TITLE
possible short term fix for #300

### DIFF
--- a/wand/image.py
+++ b/wand/image.py
@@ -2758,6 +2758,11 @@ class Image(BaseImage):
         self.raise_exception()
 
     def __exit__(self, type, value, traceback):
+        """
+        Manually remove SingleImage's in the Sequence, allowing it to
+        be properly garbage collected after using a 'with Image()' context
+        manager.
+        """
         for i in range(0, len(self.sequence)):
             self.sequence.pop()
         super(Image, self).__exit__(type, value, traceback)

--- a/wand/image.py
+++ b/wand/image.py
@@ -2757,6 +2757,11 @@ class Image(BaseImage):
             self.sequence = Sequence(self)
         self.raise_exception()
 
+    def __exit__(self, type, value, traceback):
+        for i in range(0, len(self.sequence)):
+            self.sequence.pop()
+        super(Image, self).__exit__(type, value, traceback)
+
     def read(self, file=None, filename=None, blob=None, resolution=None):
         """Read new image into Image() object.
 


### PR DESCRIPTION
Per my comment on the issue, this at least helps cleanup Python `Image` instances when using the `with` context expressions. I think there's a need to look deeper at cleaning up the `Sequence` class a bit, but this seems to work.

I manually tested for the leak in 2.7 and 3.5. I'd recommend a quick regression check as I'm not sure which tests should be passing or not as they haven't passed 100% for me on my system using either versions.